### PR TITLE
updates related to #9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: updater
 Title: Utilities for Updating R
-Version: 0.1.1.9000
+Version: 0.1.1.9001
 Authors@R: 
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0862-2018"))
@@ -14,7 +14,7 @@ URL: https://github.com/ddsjoberg/updater, https://www.danieldsjoberg.com/update
 BugReports: https://github.com/ddsjoberg/updater/issues
 Imports: 
     cli (>= 3.3.0),
-    renv (>= 0.15.5)
+    renv (>= 1.0.2)
 Suggests: 
     covr,
     spelling,
@@ -23,4 +23,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # updater (development version)
 
+* In the release of {renv} v1.0.0 release, `renv::install()` prompts users by default about the installation of each function. This default behavior has now been silenced. (#9)
+
 # updater 0.1.1
 
 * The `install_pkgs()` function can now re-install packages from the R-Universe. (#3)

--- a/R/utils.R
+++ b/R/utils.R
@@ -83,7 +83,7 @@ install_pkgs_with_renv_install <- function(df_pkgs_to_install) {
       invisible(utils::capture.output(
         do.call(
           what = renv::install,
-          args = df_pkgs_to_install$renv_install_pkg_arg[[i]]
+          args = c(df_pkgs_to_install$renv_install_pkg_arg[[i]], list(prompt = FALSE))
         )
       )),
       error = function(e) {


### PR DESCRIPTION
* In the release of {renv} v1.0.0 release, `renv::install()` prompts users by default about the installation of each function. This default behavior has now been silenced. (#9)

closes #9 
